### PR TITLE
Loosen tag name to be anything other than ().

### DIFF
--- a/example/hello-universe/Makefile
+++ b/example/hello-universe/Makefile
@@ -1,0 +1,18 @@
+SRC    := hello.c
+FRAGS  := frags.json
+DOCS   := hello.md
+OUTPUT := output.md
+
+.PHONY: all
+all: $(OUTPUT)
+	diff -q output.md expected.md
+
+$(FRAGS): $(SRC)
+	stack run -- lift $(SRC) -o $(FRAGS)
+
+$(OUTPUT): $(FRAGS) $(DOCS)
+	stack run -- weave $(DOCS) -f $(FRAGS) -o $(OUTPUT)
+
+clean:
+	rm $(FRAGS)
+	rm $(OUTPUT)

--- a/example/hello-universe/expected.md
+++ b/example/hello-universe/expected.md
@@ -1,0 +1,22 @@
+# Hello, Universe in C
+
+Traditionally, the way to kick the tires on a programming language is to
+write a program that simply prints "Hello, universe!" and exits. In C, the
+function for printing text is called `printf`, and we use it like this:
+
+```c
+printf("Hello, Universe!\n");
+```
+
+The whole program looks like this:
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+    printf("Hello, Universe!\n");
+    return EXIT_SUCCESS;
+}
+```

--- a/example/hello-universe/hello.c
+++ b/example/hello-universe/hello.c
@@ -1,0 +1,12 @@
+// loom:start(hello.c)
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void)
+{
+    // loom:start(hello.c/printf)
+    printf("Hello, Universe!\n");
+    // loom:end(hello.c/printf)
+    return EXIT_SUCCESS;
+}
+// loom:end(hello.c)

--- a/example/hello-universe/hello.md
+++ b/example/hello-universe/hello.md
@@ -1,0 +1,16 @@
+# Hello, Universe in C
+
+Traditionally, the way to kick the tires on a programming language is to
+write a program that simply prints "Hello, universe!" and exits. In C, the
+function for printing text is called `printf`, and we use it like this:
+
+```c
+loom:include(hello.c/printf)
+```
+
+The whole program looks like this:
+
+```c
+loom:include(hello.c)
+```
+

--- a/src/AirLoom/Parser.hs
+++ b/src/AirLoom/Parser.hs
@@ -100,4 +100,4 @@ loomIncludeRegex = tagRegex "loom:include"
 -- Makes a regular expression for matching a tag with the given name.
 tagRegex :: String -> String
 tagRegex s =
-  "^.*" ++ s ++ "\\(([a-zA-Z0-9_,':]+)\\).*$"
+  "^.*" ++ s ++ "\\(([^\\(\\)]+)\\).*$"


### PR DESCRIPTION
 This then allows for more descriptive tags across larger projects, e.g., by using pathnames.